### PR TITLE
fix: resolved the Error while Related to Account setting while initial company setup issue

### DIFF
--- a/india_compliance/audit_trail/setup.py
+++ b/india_compliance/audit_trail/setup.py
@@ -12,7 +12,8 @@ from india_compliance.audit_trail.utils import (
 
 def setup_fixtures():
     create_custom_fields(CUSTOM_FIELDS)
-    create_property_setters_for_versioning()
+    if "Asset" in frappe.get_installed_apps():
+        create_property_setters_for_versioning()
 
 
 def create_property_setters_for_versioning():
@@ -36,5 +37,5 @@ def create_property_setters_for_versioning():
 
 
 def after_migrate():
-    if is_audit_trail_enabled():
+    if is_audit_trail_enabled() and "Asset" in frappe.get_installed_apps():
         create_property_setters_for_versioning()

--- a/india_compliance/audit_trail/setup.py
+++ b/india_compliance/audit_trail/setup.py
@@ -12,7 +12,7 @@ from india_compliance.audit_trail.utils import (
 
 def setup_fixtures():
     create_custom_fields(CUSTOM_FIELDS)
-    if "Asset" in frappe.get_installed_apps():
+    if "assets" in frappe.get_installed_apps():
         create_property_setters_for_versioning()
 
 
@@ -37,5 +37,5 @@ def create_property_setters_for_versioning():
 
 
 def after_migrate():
-    if is_audit_trail_enabled() and "Asset" in frappe.get_installed_apps():
+    if is_audit_trail_enabled() and "assets" in frappe.get_installed_apps():
         create_property_setters_for_versioning()


### PR DESCRIPTION
The issue was caused by the missing create_property_setters_for_versioning() call, which has now been conditionally added. This prevents unnecessary operations in environments where assets is not installed while ensuring proper tracking of changes when it is.