### PR TITLE
fix: use correct update syntax for PostgreSQL in BOE patch

### DIFF
--- a/india_compliance/patches/v15/multiple_pi_in_boe.py
+++ b/india_compliance/patches/v15/multiple_pi_in_boe.py
@@ -2,14 +2,22 @@ import frappe
 
 
 def execute():
-    boe = frappe.qb.DocType("Bill of Entry", alias="boe")
-    boe_item = frappe.qb.DocType("Bill of Entry Item", alias="boe_item")
+    boe_item = frappe.qb.DocType("Bill of Entry Item")
+    boe = frappe.qb.DocType("Bill of Entry")
 
-    # link BOE Item to it's purchase invoice
-    (
-        frappe.qb.update(boe_item)
-        .join(boe)
-        .on(boe_item.parent == boe.name)
-        .set(boe_item.purchase_invoice, boe.purchase_invoice)
-        .run(as_dict=True)
-    )
+    if frappe.db.db_type == "postgres":
+        (
+            frappe.qb.update(boe_item)
+            .set(boe_item.purchase_invoice, boe.purchase_invoice)
+            .from_(boe)
+            .where(boe_item.parent == boe.name)
+            .run()
+        )
+    else:
+        (
+            frappe.qb.update(boe_item)
+            .join(boe)
+            .on(boe_item.parent == boe.name)
+            .set(boe_item.purchase_invoice, boe.purchase_invoice)
+            .run(as_dict=True)
+        )


### PR DESCRIPTION
Changes Made:
Added a check using frappe.db.db_type to determine the database type.

Used UPDATE ... FROM ... for PostgreSQL.

Retained UPDATE ... JOIN ... for MySQL/MariaDB.

Ensured compatibility across both database engines.