### PR TITLE
fix: TC_ACC_073 | corrected method name for TC_ACC_073 to validate gl accounts

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -133,7 +133,7 @@ class TestTransaction(FrappeTestCase):
             doc.taxes[0],
         )
         if doc.doctype == 'Purchase Invoice':
-            self.validate_gl_entries(doc)
+            self.validate_gl_entries_for_pi_with_rcm_to_unregistered_supplier_TC_ACC_073(doc)
 
     def validate_gl_entries_for_pi_with_rcm_to_unregistered_supplier_TC_ACC_073(self, doc):
         gl_entries = frappe.get_all(


### PR DESCRIPTION
validate_gl_accounts method doesn't exists so wrote a custom method to validate the gl_accounts and called it within the test case.