### PR TITLE
Fix issue no 80

### DIFF
--- a/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
@@ -772,6 +772,9 @@ def get_purchase_invoice_details(boe):
 def get_pi_items(purchase_invoices):
     pi_item = frappe.qb.DocType("Purchase Invoice Item")
 
+    if not purchase_invoices:
+        purchase_invoices.append("")
+
     return (
         frappe.qb.from_(pi_item)
         .select(


### PR DESCRIPTION
File "apps/frappe/frappe/database/database.py", line 236, in sql
    self._cursor.execute(query, values)
psycopg2.errors.SyntaxError: syntax error at or near ")"
LINE 1: ...ROM "tabPurchase Invoice Item" WHERE "parent" IN () AND "pen..

https://github.com/8848digital/india_compliance/issues/80