### PR TITLE
Update Docs for Commit Message Linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 exclude: "node_modules|.git"
-default_stages: [commit]
+default_stages: [pre-commit]
 fail_fast: false
 
 repos:
@@ -30,6 +30,14 @@ repos:
       hooks:
           - id: flake8
             additional_dependencies: [flake8-isort, flake8-bugbear]
+    
+    - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+      rev: v9.22.0
+      hooks:
+        - id: commitlint
+          name: Checking commit subject
+          stages: [commit-msg]
+          additional_dependencies: ['@commitlint/config-conventional','conventional-changelog-conventionalcommits']
 
 ci:
     autoupdate_schedule: weekly


### PR DESCRIPTION
### Documented Item  
Pre-commit configuration for commit message linting using `commitlint`.

### Changes Made  
- Updated section: `.pre-commit-config.yaml`  
- Added `commitlint` hook to enforce commit title conventions

### Related Feature  
Related to None