### PR TITLE
25 june to 3 july

### DIFF
--- a/india_compliance/audit_trail/overrides/property_setter.py
+++ b/india_compliance/audit_trail/overrides/property_setter.py
@@ -9,11 +9,9 @@ from india_compliance.audit_trail.utils import (
 
 
 def validate(doc, method=None):
-    if (
-        frappe.flags.in_install
-        or frappe.flags.in_migrate
-        or not is_audit_trail_enabled()
-    ):
+    flags = frappe.local.flags
+
+    if flags.in_install or flags.in_migrate or not is_audit_trail_enabled():
         return
 
     is_protected = is_protected_property_setter(doc)
@@ -29,7 +27,14 @@ def validate(doc, method=None):
 
 
 def on_trash(doc, method=None):
-    if not is_audit_trail_enabled() or not is_protected_property_setter(doc):
+    flags = frappe.local.flags
+
+    if (
+        flags.in_install
+        or flags.in_migrate
+        or not is_audit_trail_enabled()
+        or not is_protected_property_setter(doc)
+    ):
         return
 
     throw_cannot_change_property_error(doc)

--- a/india_compliance/gst_india/client_scripts/purchase_invoice.js
+++ b/india_compliance/gst_india/client_scripts/purchase_invoice.js
@@ -106,7 +106,7 @@ function toggle_reverse_charge(frm) {
     let is_read_only = 0;
     if (frm.doc.gst_category !== "Overseas") is_read_only = 0;
     // has_goods_item
-    else if (frm.doc.items.some(item => !item.gst_hsn_code.startsWith("99")))
+    else if (frm.doc.items.length > 0 && frm.doc.items.some(item => !item.gst_hsn_code.startsWith("99")))
         is_read_only = 1;
 
     frm.set_df_property("is_reverse_charge", "read_only", is_read_only);

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -799,6 +799,11 @@ class GSTR1 {
     }
 
     async show_suggested_jv_dialog() {
+        await this.show_rounding_diff_journal_entry();
+        await this.show_rcm_journal_entry();
+    }
+
+    async show_rcm_journal_entry() {
         if (!frappe.perm.has_perm("Journal Entry")) return;
 
         const { month_or_quarter, year, company, filing_preference } = this.frm.doc;
@@ -810,9 +815,111 @@ class GSTR1 {
         if (!je_details) return;
 
         this.create_journal_entry_dialog(je_details);
+        return new Promise(resolve => {
+            const remarks = `Reduced Output GST Liability to the extent of Sales Reverse Charge as per GSTR-1 for ${this.frm.doc.month_or_quarter} - ${this.frm.doc.year}`;
+            const dialog = this.create_journal_entry_dialog(je_details, remarks);
+
+            dialog.onhide = () => {
+                resolve();
+            };
+
+            dialog.show();
+        });
     }
 
-    create_journal_entry_dialog(je_details) {
+     TAX_TO_ACCOUNT_MAP = {
+        total_igst_amount: "igst_account",
+        total_cgst_amount: "cgst_account",
+        total_sgst_amount: "sgst_account",
+        total_cess_amount: ["cess_account", "cess_non_advol_account"],
+    };
+
+    async show_rounding_diff_journal_entry() {
+        if (!frappe.perm.has_perm("Journal Entry")) return;
+
+        let rounding_difference = this.data.books?.rounding_difference[0];
+        if (!rounding_difference || Object.values(rounding_difference).every(v => !v))
+            return;
+
+        const { month_or_quarter, year, company, filing_preference } = this.frm.doc;
+        const { message: data } = await frappe.call({
+            method: "india_compliance.gst_india.doctype.gstr_1_beta.gstr_1_beta.get_gst_and_round_off_accounts",
+            args: { month_or_quarter, year, company, filing_preference },
+        });
+
+        if (!data) return;
+
+        return new Promise(resolve => {
+            const dialog = this.create_rounding_diff_journal_entry(
+                data.account,
+                data.posting_date
+            );
+
+            if (!dialog) return resolve();
+
+            dialog.onhide = () => {
+                resolve();
+            };
+
+            dialog.show();
+        });
+    }
+
+    create_rounding_diff_journal_entry(account, posting_date) {
+        let rounding_difference = this.data.books?.rounding_difference[0];
+
+        const je_details = {
+            posting_date: posting_date,
+            data: [],
+        };
+
+        const get_account_name = account_field => {
+            if (!Array.isArray(account_field)) return account[account_field];
+            for (const acc of account_field) {
+                if (account[acc]) {
+                    return account[acc];
+                }
+            }
+            return null;
+        };
+
+        let total = 0;
+
+        for (const [tax_field, account_field] of Object.entries(
+            this.TAX_TO_ACCOUNT_MAP
+        )) {
+            let value = rounding_difference[tax_field];
+
+            if (!value) continue;
+
+            let account_name = get_account_name(account_field);
+
+            if (!account_name) continue;
+
+            total += value;
+
+            je_details.data.push({
+                account: account_name,
+                debit_in_account_currency: value > 0 ? value : 0,
+                credit_in_account_currency: value < 0 ? Math.abs(value) : 0,
+            });
+        }
+
+        if (je_details.data.length === 0) return;
+
+        if (total !== 0) {
+            je_details.data.push({
+                account: account.round_off_account,
+                debit_in_account_currency: total < 0 ? Math.abs(total) : 0,
+                credit_in_account_currency: total > 0 ? total : 0,
+            });
+        }
+
+        const remarks = `Rounding Difference in Output GST Liability for ${this.frm.doc.month_or_quarter} - ${this.frm.doc.year}`;
+        return this.create_journal_entry_dialog(je_details, remarks);
+    }
+
+    create_journal_entry_dialog(je_details, remarks) {
         const dialog = new frappe.ui.Dialog({
             title: "Suggested Journal Entry",
             fields: [
@@ -833,7 +940,7 @@ class GSTR1 {
                     fieldtype: "Text",
                     label: "Remarks",
                     read_only: 1,
-                    default: `Reduced Output GST Liability to the extent of Sales Reverse Charge as per GSTR-1 for ${this.frm.doc.month_or_quarter} - ${this.frm.doc.year}`,
+                    default: remarks,
                 },
                 {
                     fieldname: "auto_submit",
@@ -865,7 +972,7 @@ class GSTR1 {
             },
         });
 
-        dialog.show();
+        return dialog;
     }
 
     generate_tax_table(data) {
@@ -935,6 +1042,7 @@ class TabManager {
         this.data = data;
         this.summary = summary_data;
         this.status = status;
+        this.rounding_difference = this.data?.rounding_difference[0];
         this.remove_tab_custom_buttons();
         this.setup_actions();
         this.datatable.refresh(this.summary, null, this.get_no_data_message());
@@ -1100,9 +1208,15 @@ class TabManager {
                     },
                 },
             },
+            ...this.get_additional_datatable_config(),
         });
 
         this.setup_datatable_listeners(treeView);
+    }
+
+    get_additional_datatable_config() {
+        // Override this method in subclasses to provide additional configuration
+        return {};
     }
 
     setup_datatable_listeners(isSummaryView) {
@@ -1733,6 +1847,26 @@ class BooksTab extends GSTR1_TabManager {
 
     DEFAULT_TITLE = "Summary of Books";
 
+    get_additional_datatable_config() {
+        return {
+            additional_total_rows: [
+                {
+                    label: "Rounding Difference",
+                    row_id: "rounding_difference",
+                    label_column: "description",
+                    exclude_columns: ["_rowIndex", "_checkbox", "no_of_records"],
+                    data: () => this.rounding_difference,
+                    show: () => {
+                        if (!this.rounding_difference) return false;
+
+                        return Object.values(this.rounding_difference).some(v => v);
+                    },
+                    css_styles: { "font-weight": "bold" },
+                },
+            ],
+        };
+    }
+
     setup_actions() {
         this.add_tab_custom_button("Download Excel", () =>
             this.download_books_as_excel()
@@ -1744,7 +1878,6 @@ class BooksTab extends GSTR1_TabManager {
         data = super.filter_data(data, filters);
         return data.filter(row => row.upload_status !== "Missing in Books");
     }
-
     // ACTIONS
 
     download_books_as_excel() {

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -2629,6 +2629,7 @@ class FileGSTR1Dialog {
 
                 this.update_actions_for_filing(pan);
             },
+            static: true,
         });
 
         // get last used pan
@@ -2667,7 +2668,8 @@ class FileGSTR1Dialog {
                 this.filing_dialog.refresh();
             },
         });
-
+        
+        this.filing_dialog.get_close_btn().show();
         this.filing_dialog.show();
     }
 

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
@@ -302,6 +302,58 @@ def get_journal_entries(month_or_quarter, year, company, filing_preference):
 
     return {"data": data, "posting_date": to_date}
 
+@frappe.whitelist()
+def get_gst_and_round_off_accounts(month_or_quarter, year, company, filing_preference):
+    """
+    Get GST output accounts and round off account for journal entry creation.
+
+    Returns:
+        dict: Contains account details and posting date, or None if accounts not found
+    """
+    if not frappe.has_permission("Journal Entry", "create"):
+        return
+
+    _, to_date = get_gstr_1_from_and_to_date(month_or_quarter, year, filing_preference)
+
+    # Get Output GST accounts using existing utility
+    try:
+        gst_accounts = get_gst_accounts_by_type(company, "Output")
+
+    except Exception:
+        return
+
+    if not gst_accounts:
+        return
+
+    # For Round Off Account
+    round_off_account = frappe.get_all(
+        "Account",
+        filters={
+            "company": company,
+            "account_type": "Round Off",
+        },
+        pluck="name",
+    )
+
+    if not round_off_account:
+        return
+
+    round_off_account = round_off_account[0]
+
+    account = {
+        "igst_account": gst_accounts.get("igst_account"),
+        "cgst_account": gst_accounts.get("cgst_account"),
+        "sgst_account": gst_accounts.get("sgst_account"),
+        "cess_account": gst_accounts.get("cess_account"),
+        "cess_non_advol_account": gst_accounts.get("cess_non_advol_account"),
+        "round_off_account": round_off_account,
+    }
+
+    return {
+        "account": account,
+        "posting_date": to_date,
+    }
+
 
 @frappe.whitelist()
 def make_journal_entry(

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.js
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.js
@@ -1,0 +1,76 @@
+// Copyright (c) 2025, Resilient Tech and contributors
+// For license information, please see license.txt
+
+frappe.query_reports["Summary of Inward Supplies"] = {
+    filters: [
+        {
+            fieldname: "company",
+            label: __("Company"),
+            fieldtype: "Link",
+            options: "Company",
+            reqd: 1,
+            default: frappe.defaults.get_user_default("Company"),
+            on_change: report => {
+                report.set_filter_value({
+                    company_gstin: "",
+                });
+                report.refresh();
+            },
+            get_query: function () {
+                return {
+                    filters: {
+                        country: "India",
+                    },
+                };
+            },
+        },
+        {
+            fieldname: "company_gstin",
+            label: __("Company GSTIN"),
+            fieldtype: "Autocomplete",
+            get_query: function () {
+                const company = frappe.query_report.get_filter_value("company");
+                return india_compliance.get_gstin_query(company);
+            },
+        },
+        {
+            fieldname: "date_range",
+            label: __("Date Range"),
+            fieldtype: "DateRange",
+            default: [
+                india_compliance.last_month_start(),
+                india_compliance.last_month_end(),
+            ],
+            reqd: 1,
+            width: "80",
+        }
+    ],
+
+    formatter: (value, row, column, data, default_formatter) => {
+        value = default_formatter(value, row, column, data);
+        if (data && data.indent === 0) {
+            let $value = $(`<span>${value}</span>`).css("font-weight", "bold");
+            value = $value.wrap("<p></p>").parent().html();
+        }
+
+        return value;
+    },
+
+    // Override datatable hook for column total calculation
+    get_datatable_options(datatable_options) {
+        datatable_options.hooks = {
+            columnTotal: function (...args) {
+                return this.datamanager.data.reduce((acc, row) => {
+                    const column_field = args[1].column.fieldname;
+                    if (column_field === "details") return;
+
+                    if (row.indent !== 1) { acc += row[column_field] || 0; }
+
+                    return acc;
+                }, 0);
+            },
+        };
+
+        return datatable_options;
+    },
+};

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.js
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.js
@@ -56,18 +56,20 @@ frappe.query_reports["Summary of Inward Supplies"] = {
         return value;
     },
 
-    // Override datatable hook for column total calculation
     get_datatable_options(datatable_options) {
         datatable_options.hooks = {
             columnTotal: function (...args) {
-                const total = this.datamanager.data.reduce((acc, row) => {
-                    const column_field = args[1].column.fieldname;
-                    if (column_field === "details") return;
+                const column_field = args[1].column.fieldname;
+                if (column_field === "details") return;
 
-                    if (row.indent !== 1) { acc += row[column_field] || 0; }
+                const total = this.datamanager.data.reduce((acc, row) => {
+                    if (row.indent === 0) {
+                        acc += row[column_field] || 0;
+                    }
 
                     return acc;
                 }, 0);
+
                 return total;
             },
         };

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.js
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.js
@@ -60,7 +60,7 @@ frappe.query_reports["Summary of Inward Supplies"] = {
     get_datatable_options(datatable_options) {
         datatable_options.hooks = {
             columnTotal: function (...args) {
-                return this.datamanager.data.reduce((acc, row) => {
+                const total = this.datamanager.data.reduce((acc, row) => {
                     const column_field = args[1].column.fieldname;
                     if (column_field === "details") return;
 
@@ -68,6 +68,7 @@ frappe.query_reports["Summary of Inward Supplies"] = {
 
                     return acc;
                 }, 0);
+                return total;
             },
         };
 

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.json
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.json
@@ -1,0 +1,37 @@
+{
+ "add_total_row": 1,
+ "add_translate_data": 0,
+ "columns": [],
+ "creation": "2025-11-06 13:01:51.249629",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letterhead": null,
+ "modified": "2025-11-06 13:01:51.249629",
+ "modified_by": "Administrator",
+ "module": "GST India",
+ "name": "Summary of Inward Supplies",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Purchase Invoice",
+ "report_name": "Summary of Inward Supplies",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "Accounts User"
+  },
+  {
+   "role": "Purchase User"
+  },
+  {
+   "role": "Accounts Manager"
+  },
+  {
+   "role": "Auditor"
+  }
+ ],
+ "timeout": 0
+}

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
@@ -1,0 +1,282 @@
+# Copyright (c) 2025, Resilient Tech and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.query_builder import Case
+from frappe.query_builder.functions import LiteralValue
+
+MAPPING_FIELD = {
+    1: {
+        "title": "Inward supplies (other than imports and inward supplies liable to reverse charge but includes services received from SEZs)",
+        "get_detail_type": lambda row: row.get("gst_category") != "Overseas"
+        and row.get("is_reverse_charge") == 0,
+    },
+    2: {
+        "title": "Inward supplies received from unregistered persons liable to reverse charge (other than B above) on which tax is paid & ITC availed",
+        "get_detail_type": lambda row: row.get("gst_category") == "Unregistered"
+        and row.get("is_reverse_charge") == 1
+        and row.get("is_ineligible_for_itc") == 0,
+    },
+    3: {
+        "title": "Inward supplies received from registered persons liable to reverse charge (other than B above) on which tax is paid & ITC availed",
+        "get_detail_type": lambda row: row.get("gst_category") != "Unregistered"
+        and row.get("is_reverse_charge") == 1
+        and row.get("is_ineligible_for_itc") == 0,
+    },
+    4: {
+        "title": "Import Of Goods",
+        "get_detail_type": lambda row: row.get("itc_classification")
+        == "Import Of Goods",
+    },
+    5: {
+        "title": "Import Of Services",
+        "get_detail_type": lambda row: row.get("itc_classification")
+        == "Import Of Service"
+        and row.get("gst_category") != "SEZ",
+    },
+    6: {
+        "title": "Input Tax credit received from ISD",
+        "get_detail_type": lambda row: row.get("itc_classification")
+        == "Input Service Distributor",
+    },
+}
+
+
+def execute(filters: dict | None = None) -> tuple[list[dict], list[dict]]:
+    return get_columns(), get_data(filters)
+
+
+def get_columns() -> list[dict]:
+    return [
+        {
+            "label": _("Details"),
+            "fieldname": "details",
+            "fieldtype": "Data",
+            "width": 1000,
+        },
+        {
+            "label": _("Integrated tax (₹)"),
+            "fieldname": "integrated_tax",
+            "fieldtype": "Currency",
+            "width": 150,
+        },
+        {
+            "label": _("Central tax (₹)"),
+            "fieldname": "central_tax",
+            "fieldtype": "Currency",
+            "width": 150,
+        },
+        {
+            "label": _("State/UT tax (₹)"),
+            "fieldname": "state_ut_tax",
+            "fieldtype": "Currency",
+            "width": 150,
+        },
+        {
+            "label": _("Cess (₹)"),
+            "fieldname": "cess",
+            "fieldtype": "Currency",
+            "width": 150,
+        },
+    ]
+
+
+def get_data(filters) -> list[dict]:
+    data = []
+    data.extend(get_purchase_invoice_data(filters))
+    data.extend(get_bill_of_entry_data(filters))
+
+    summary = get_initial_summary()
+
+    for row in data:
+        detail_type = get_detail_type(row)
+        if detail_type in (1, 2, 3, 4):
+            add_subcategory_summary(summary[detail_type], row)
+
+        elif detail_type in (5, 6):
+            summary[detail_type]["integrated_tax"] += row.igst_amount
+            summary[detail_type]["central_tax"] += row.cgst_amount
+            summary[detail_type]["state_ut_tax"] += row.sgst_amount
+            summary[detail_type]["cess"] += row.cess_amount
+
+    return get_transformed_summary(summary)
+
+
+def get_purchase_invoice_data(filters: dict) -> list[list]:
+    doc = frappe.qb.DocType("Purchase Invoice")
+    doc_item = frappe.qb.DocType("Purchase Invoice Item")
+
+    from_date, to_date = filters.date_range
+
+    query = (
+        frappe.qb.from_(doc)
+        .inner_join(doc_item)
+        .on(doc.name == doc_item.parent)
+        .select(
+            doc.gst_category.as_("gst_category"),
+            doc.itc_classification.as_("itc_classification"),
+            doc_item.is_ineligible_for_itc.as_("is_ineligible_for_itc"),
+            doc_item.is_fixed_asset.as_("is_fixed_asset"),
+            doc.is_reverse_charge.as_("is_reverse_charge"),
+            doc_item.gst_hsn_code.as_("gst_hsn_code"),
+            doc_item.cgst_amount.as_("cgst_amount"),
+            doc_item.sgst_amount.as_("sgst_amount"),
+            doc_item.igst_amount.as_("igst_amount"),
+            (doc_item.cess_amount + doc_item.cess_non_advol_amount).as_("cess_amount"),
+        )
+        .where(
+            (doc.docstatus == 1)
+            & (doc.posting_date[from_date:to_date])
+            & (doc.company == filters.company)
+            & (doc.is_opening == "No")
+        )
+    )
+
+    if filters.get("company_gstin"):
+        query = query.where(doc.company_gstin == filters.company_gstin)
+
+    return query.run(as_dict=True, debug=True)
+
+
+def get_bill_of_entry_data(filters: dict) -> list[list]:
+    doc = frappe.qb.DocType("Bill of Entry")
+    item = frappe.qb.DocType("Item")
+    doc_item = frappe.qb.DocType("Bill of Entry Item")
+
+    from_date, to_date = filters.date_range
+
+    query = (
+        frappe.qb.from_(doc)
+        .inner_join(doc_item)
+        .on(doc.name == doc_item.parent)
+        .inner_join(item)
+        .on(doc_item.item_code == item.name)
+        .select(
+            Case("itc_classification")
+            .when(doc_item.gst_hsn_code.like("99%"), "Import Of Service")
+            .else_("Import Of Goods"),
+            LiteralValue("'Overseas'").as_("gst_category"),
+            LiteralValue(False).as_("is_reverse_charge"),
+            item.is_fixed_asset.as_("is_fixed_asset"),
+            doc_item.gst_hsn_code.as_("gst_hsn_code"),
+            doc_item.cgst_amount.as_("cgst_amount"),
+            doc_item.sgst_amount.as_("sgst_amount"),
+            doc_item.igst_amount.as_("igst_amount"),
+            (doc_item.cess_amount + doc_item.cess_non_advol_amount).as_("cess_amount"),
+        )
+        .where(
+            (doc.docstatus == 1)
+            & (doc.posting_date[from_date:to_date])
+            & (doc.company == filters.company)
+        )
+    )
+
+    return query.run(as_dict=True, debug=True)
+
+
+def get_initial_summary() -> dict:
+    _tax_amount = {
+        "integrated_tax": 0,
+        "central_tax": 0,
+        "state_ut_tax": 0,
+        "cess": 0,
+    }
+
+    return {
+        1: {
+            "Inputs": {**_tax_amount},
+            "Capital Goods": {**_tax_amount},
+            "Input Services": {**_tax_amount},
+        },
+        2: {
+            "Inputs": {**_tax_amount},
+            "Capital Goods": {**_tax_amount},
+            "Input Services": {**_tax_amount},
+        },
+        3: {
+            "Inputs": {**_tax_amount},
+            "Capital Goods": {**_tax_amount},
+            "Input Services": {**_tax_amount},
+        },
+        4: {
+            "Inputs": {**_tax_amount},
+            "Capital Goods": {**_tax_amount},
+        },
+        5: {**_tax_amount},
+        6: {**_tax_amount},
+    }
+
+
+def get_detail_type(row) -> int:
+    for detail_type, mapping in MAPPING_FIELD.items():
+        if mapping["get_detail_type"](row):
+            return detail_type
+
+
+def add_subcategory_summary(summary, row) -> dict:
+    if row["is_fixed_asset"] == 1:
+        key = "Capital Goods"
+
+    elif row["gst_hsn_code"] and row["gst_hsn_code"].startswith("99"):
+        key = "Input Services"
+    else:
+        key = "Inputs"
+
+    summary[key]["integrated_tax"] += row.igst_amount
+    summary[key]["central_tax"] += row.cgst_amount
+    summary[key]["state_ut_tax"] += row.sgst_amount
+    summary[key]["cess"] += row.cess_amount
+
+
+def get_transformed_summary(summary) -> list[dict]:
+    transformed_summary = []
+    for detail_type, subcategory in summary.items():
+        if detail_type in (1, 2, 3, 4):
+            transformed_summary.append(
+                {
+                    "details": MAPPING_FIELD[detail_type]["title"],
+                    "integrated_tax": sum(
+                        [
+                            subcategory[subcat]["integrated_tax"]
+                            for subcat in subcategory
+                        ]
+                    ),
+                    "central_tax": sum(
+                        [subcategory[subcat]["central_tax"] for subcat in subcategory]
+                    ),
+                    "state_ut_tax": sum(
+                        [subcategory[subcat]["state_ut_tax"] for subcat in subcategory]
+                    ),
+                    "cess": sum(
+                        [subcategory[subcat]["cess"] for subcat in subcategory]
+                    ),
+                    "indent": 0,
+                }
+            )
+
+            for subcategory_name, tax_amounts in subcategory.items():
+                transformed_summary.append(
+                    {
+                        "details": subcategory_name,
+                        "integrated_tax": tax_amounts["integrated_tax"],
+                        "central_tax": tax_amounts["central_tax"],
+                        "state_ut_tax": tax_amounts["state_ut_tax"],
+                        "cess": tax_amounts["cess"],
+                        "indent": 1,
+                    }
+                )
+
+        else:
+            transformed_summary.append(
+                {
+                    "details": MAPPING_FIELD[detail_type]["title"],
+                    "integrated_tax": subcategory["integrated_tax"],
+                    "central_tax": subcategory["central_tax"],
+                    "state_ut_tax": subcategory["state_ut_tax"],
+                    "cess": subcategory["cess"],
+                    "indent": 0,
+                }
+            )
+
+    return transformed_summary

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
@@ -26,7 +26,8 @@ MAPPING_FIELD = {
     },
     4: {
         "title": "Import Of Goods (including supplies from SEZ)",
-        "is_part_of": lambda row: row.get("itc_classification") == "Import Of Goods",
+        "is_part_of": lambda row: row.get("itc_classification") == "Import Of Goods"
+        and row.get("gst_category") == "SEZ",
     },
     5: {
         "title": "Import Of Services (excluding inward supplies from SEZ)",

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
@@ -66,14 +66,17 @@ class InwardSuppliesGSTSummaryMapping:
 class InwardSuppliesGSTSummaryCategory(InwardSuppliesGSTSummaryMapping):
     def __init__(self) -> None:
         super().__init__()
-        self.mapping["A"]["category"] = self._is_inward_supplies_from_registered
-        self.mapping["B"]["category"] = self._is_inward_supplies_from_unregistered
-        self.mapping["C"][
-            "category"
-        ] = self._is_inward_supplies_from_registered_reverse_charge
-        self.mapping["D"]["category"] = self._is_import_of_goods_sez
-        self.mapping["E"]["category"] = self._is_import_of_services
-        self.mapping["F"]["category"] = self._is_itc_received_from_isd
+        category_map = {
+            "A": self._is_inward_supplies_from_registered,
+            "B": self._is_inward_supplies_from_unregistered,
+            "C": self._is_inward_supplies_from_registered_reverse_charge,
+            "D": self._is_import_of_goods_sez,
+            "E": self._is_import_of_services,
+            "F": self._is_itc_received_from_isd,
+        }
+
+        for key, func in category_map.items():
+            self.mapping[key]["category"] = func
 
     def _is_inward_supplies_from_registered(self, row: dict) -> bool:
         return (

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025, Resilient Tech and contributors
 # For license information, please see license.txt
 
+from enum import Enum
 from itertools import chain
 
 import frappe
@@ -21,107 +22,101 @@ def execute(filters: dict | None = None) -> tuple[list[dict], list[dict]]:
     return report.get_columns(), report.get_data()
 
 
-class InwardSuppliesGSTSummaryMapping:
-    def __init__(self) -> None:
-        self.mapping = {
-            "A": {
-                "title": "Inward supplies (other than imports and inward supplies liable to reverse charge but includes services received from SEZs)",
-                "category": ...,
-                "has_subcategory": True,
-            },
-            "B": {
-                "title": "Inward supplies received from unregistered persons liable to reverse charge (other than A above) on which tax is paid & ITC availed",
-                "category": ...,
-                "has_subcategory": True,
-            },
-            "C": {
-                "title": "Inward supplies received from registered persons liable to reverse charge (other than A above) on which tax is paid & ITC availed",
-                "category": ...,
-                "has_subcategory": True,
-            },
-            "D": {
-                "title": "Import Of Goods (including supplies from SEZ)",
-                "category": ...,
-                "has_subcategory": True,
-            },
-            "E": {
-                "title": "Import Of Services (excluding inward supplies from SEZ)",
-                "category": ...,
-                "has_subcategory": False,
-            },
-            "F": {
-                "title": "Input Tax credit received from ISD",
-                "category": ...,
-                "has_subcategory": False,
-            },
-        }
+class InwardSuppliesCategory(Enum):
+    INWARD_DOMESTIC = "Inward supplies (other than imports and inward supplies liable to reverse charge but includes services received from SEZs)"
 
-    def get_title(self, category: str) -> str:
-        return self.mapping.get(category, {}).get("title")
+    UNREG_RCM = "Inward supplies received from unregistered persons liable to reverse charge (other than A above) on which tax is paid & ITC availed"
 
-    def has_subcategory(self, category: str) -> bool:
-        return self.mapping.get(category, {}).get("has_subcategory", False)
+    REG_RCM = "Inward supplies received from registered persons liable to reverse charge (other than A above) on which tax is paid & ITC availed"
+
+    IMPORT_GOODS = "Import Of Goods (including supplies from SEZ)"
+
+    IMPORT_SERVICES = "Import Of Services (excluding inward supplies from SEZ)"
+
+    ITC_FROM_ISD = "Input Tax credit received from ISD"
+
+    @property
+    def title(self) -> str:
+        return self.value
+
+    @property
+    def has_subcategory(self) -> bool:
+        return bool(INWARD_SUPPLIES_CATEGORY_MAPPING.get(self))
 
 
-class InwardSuppliesGSTSummaryCategory(InwardSuppliesGSTSummaryMapping):
-    def __init__(self) -> None:
-        super().__init__()
-        category_map = {
-            "A": self._is_inward_supplies_from_registered,
-            "B": self._is_inward_supplies_from_unregistered,
-            "C": self._is_inward_supplies_from_registered_reverse_charge,
-            "D": self._is_import_of_goods_sez,
-            "E": self._is_import_of_services,
-            "F": self._is_itc_received_from_isd,
-        }
+class InwardSuppliesSubCategory:
+    INPUTS = "Inputs"
+    CAPITAL_GOODS = "Capital Goods"
+    INPUT_SERVICES = "Input Services"
 
-        for key, func in category_map.items():
-            self.mapping[key]["category"] = func
 
-    def _is_inward_supplies_from_registered(self, row: dict) -> bool:
-        return (
-            row.get("gst_category") != "Overseas"
-            and not row.get("is_reverse_charge")
-            and row.get("itc_classification") != "Input Service Distributor"
-        )
+INWARD_SUPPLIES_CATEGORY_MAPPING = {
+    InwardSuppliesCategory.INWARD_DOMESTIC: [
+        InwardSuppliesSubCategory.INPUTS,
+        InwardSuppliesSubCategory.CAPITAL_GOODS,
+        InwardSuppliesSubCategory.INPUT_SERVICES,
+    ],
+    InwardSuppliesCategory.UNREG_RCM: [
+        InwardSuppliesSubCategory.INPUTS,
+        InwardSuppliesSubCategory.CAPITAL_GOODS,
+        InwardSuppliesSubCategory.INPUT_SERVICES,
+    ],
+    InwardSuppliesCategory.REG_RCM: [
+        InwardSuppliesSubCategory.INPUTS,
+        InwardSuppliesSubCategory.CAPITAL_GOODS,
+        InwardSuppliesSubCategory.INPUT_SERVICES,
+    ],
+    InwardSuppliesCategory.IMPORT_GOODS: [
+        InwardSuppliesSubCategory.INPUTS,
+        InwardSuppliesSubCategory.CAPITAL_GOODS,
+    ],
+    InwardSuppliesCategory.IMPORT_SERVICES: None,
+    InwardSuppliesCategory.ITC_FROM_ISD: None,
+}
 
-    def _is_inward_supplies_from_unregistered(self, row: dict) -> bool:
-        return row.get("gst_category") == "Unregistered" and row.get(
-            "is_reverse_charge"
-        )
 
-    def _is_inward_supplies_from_registered_reverse_charge(self, row: dict) -> bool:
-        return row.get("gst_category") != "Unregistered" and row.get(
-            "is_reverse_charge"
-        )
+class InwardSuppliesGSTSummaryCategory:
+    def get_category(self, row: dict) -> None:
+        gst_category = row.get("gst_category")
+        itc_classification = row.get("itc_classification")
+        is_reverse_charge = row.get("is_reverse_charge")
 
-    def _is_import_of_goods_sez(self, row: dict) -> bool:
-        return row.get("itc_classification") == "Import Of Goods"
+        if (
+            gst_category != "Overseas"
+            and not is_reverse_charge
+            and itc_classification != "Input Service Distributor"
+        ):
+            return InwardSuppliesCategory.INWARD_DOMESTIC
 
-    def _is_import_of_services(self, row: dict) -> bool:
-        return row.get("itc_classification") == "Import Of Service"
+        elif gst_category == "Unregistered" and is_reverse_charge:
+            return InwardSuppliesCategory.UNREG_RCM
 
-    def _is_itc_received_from_isd(self, row: dict) -> bool:
-        return row.get("itc_classification") == "Input Service Distributor"
+        elif gst_category != "Unregistered" and is_reverse_charge:
+            return InwardSuppliesCategory.REG_RCM
 
-    def get_category(self, row: dict) -> str:
-        for detail_type, mapping in self.mapping.items():
-            if (fn := mapping["category"]) and fn(row):
-                return detail_type
+        elif itc_classification == "Import Of Goods":
+            return InwardSuppliesCategory.IMPORT_GOODS
 
-    def get_subcategory(self, category: str, row: dict) -> str | None:
-        if not self.has_subcategory(category):
+        elif itc_classification == "Import Of Service":
+            return InwardSuppliesCategory.IMPORT_SERVICES
+
+        elif itc_classification == "Input Service Distributor":
+            return InwardSuppliesCategory.ITC_FROM_ISD
+
+    def get_subcategory(self, row: dict, category: InwardSuppliesCategory) -> None:
+        if not category.has_subcategory:
             return None
 
         if row.get("is_fixed_asset") == 1:
-            return "Capital Goods"
+            return InwardSuppliesSubCategory.CAPITAL_GOODS
 
-        if (gst_hsn_code := row.get("gst_hsn_code")) and (
+        elif (gst_hsn_code := row.get("gst_hsn_code")) and (
             gst_hsn_code.startswith("99")
         ):
-            return "Input Services"
+            return InwardSuppliesSubCategory.INPUT_SERVICES
 
-        return "Inputs"
+        else:
+            return InwardSuppliesSubCategory.INPUTS
 
 
 class InwardSuppliesGSTSummaryData:
@@ -208,37 +203,23 @@ class InwardSuppliesGSTSummary(
     InwardSuppliesGSTSummaryCategory, InwardSuppliesGSTSummaryData
 ):
     def __init__(self, filters: dict) -> None:
-        super().__init__()
         filters.from_date, filters.to_date = filters.get("date_range")
         self.filters = filters
-        self._init_summary()
 
-    def _init_summary(self) -> None:
+    def get_init_summary(self) -> None:
         _zero_taxes = {tax_field: 0 for tax_field in TAX_FIELDS}
 
-        self.summary = {
-            "A": {
-                "Inputs": {**_zero_taxes},
-                "Capital Goods": {**_zero_taxes},
-                "Input Services": {**_zero_taxes},
-            },
-            "B": {
-                "Inputs": {**_zero_taxes},
-                "Capital Goods": {**_zero_taxes},
-                "Input Services": {**_zero_taxes},
-            },
-            "C": {
-                "Inputs": {**_zero_taxes},
-                "Capital Goods": {**_zero_taxes},
-                "Input Services": {**_zero_taxes},
-            },
-            "D": {
-                "Inputs": {**_zero_taxes},
-                "Capital Goods": {**_zero_taxes},
-            },
-            "E": {**_zero_taxes},
-            "F": {**_zero_taxes},
-        }
+        summary = {}
+
+        for category, subcategories in INWARD_SUPPLIES_CATEGORY_MAPPING.items():
+            if subcategories:
+                summary[category] = {
+                    subcategory: _zero_taxes.copy() for subcategory in subcategories
+                }
+            else:
+                summary[category] = _zero_taxes.copy()
+
+        return summary
 
     def get_columns(self) -> list[dict]:
         return [
@@ -277,45 +258,45 @@ class InwardSuppliesGSTSummary(
     def get_data(self) -> list[dict]:
         data = self._get_data(self.filters)
 
+        summary = self.get_init_summary()
+
         for row in data:
-            self._add_to_summary(row)
+            category = self.get_category(row)
+            sub_category = self.get_subcategory(row, category)
 
-        return self._build_transformed_summary()
+            _summary_dict = summary.get(category)
 
-    def _add_to_summary(self, row: dict) -> None:
-        category = self.get_category(row)
-        subcategory = self.get_subcategory(category, row)
+            if sub_category:
+                _summary_dict = _summary_dict.get(sub_category)
 
-        if subcategory:
-            summary_entry = self.summary[category][subcategory]
-        else:
-            summary_entry = self.summary[category]
+            for tax_field in TAX_FIELDS:
+                _summary_dict[tax_field] += row.get(tax_field, 0)
 
-        for tax_field in TAX_FIELDS:
-            summary_entry[tax_field] += row.get(tax_field, 0)
+        return self._build_transformed_summary(summary)
 
-    def _build_transformed_summary(self) -> list[dict]:
+    def _build_transformed_summary(self, summary: dict) -> list[dict]:
         transformed = []
 
-        for category, summary in self.summary.items():
-            title = self.get_title(category)
-            has_subcategory = self.has_subcategory(category)
+        for idx, (category, _summary) in enumerate(summary.items()):
+            letter = chr(65 + idx)  # 65 is 'A'
+            title = category.title
+            has_subcategory = category.has_subcategory
 
             transformed.append(
                 self._create_entry(
-                    f"{category}) {title}",
-                    self._aggregate_summary(summary) if has_subcategory else summary,
+                    f"{letter}) {title}",
+                    self._aggregate_summary(_summary) if has_subcategory else _summary,
                     indent=0,
                 )
             )
 
             if has_subcategory:
-                for subcategory, sub_summary in summary.items():
+                for subcategory, sub_summary in _summary.items():
                     transformed.append(
                         self._create_entry(subcategory, sub_summary, indent=1)
                     )
             else:
-                transformed.append(self._create_entry(title, summary, indent=1))
+                transformed.append(self._create_entry(title, _summary, indent=1))
 
         return transformed
 

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
@@ -151,15 +151,15 @@ class InwardSuppliesGSTSummaryData:
             )
             .where(
                 (doc.docstatus == 1)
-                & (doc.posting_date[filters.from_date : filters.to_date])
-                & (doc.company == filters.company)
+                & (doc.posting_date[filters.get("from_date") : filters.get("to_date")])
+                & (doc.company == filters.get("company"))
                 & (doc.company_gstin != doc.supplier_gstin)
                 & (doc.is_opening == "No")
             )
         )
 
         if filters.get("company_gstin"):
-            query = query.where(doc.company_gstin == filters.company_gstin)
+            query = query.where(doc.company_gstin == filters.get("company_gstin"))
 
         return query.run(as_dict=True)
 
@@ -190,13 +190,13 @@ class InwardSuppliesGSTSummaryData:
             )
             .where(
                 (doc.docstatus == 1)
-                & (doc.posting_date[filters.from_date : filters.to_date])
-                & (doc.company == filters.company)
+                & (doc.posting_date[filters.get("from_date") : filters.get("to_date")])
+                & (doc.company == filters.get("company"))
             )
         )
 
         if filters.get("company_gstin"):
-            query = query.where(doc.company_gstin == filters.company_gstin)
+            query = query.where(doc.company_gstin == filters.get("company_gstin"))
 
         return query.run(as_dict=True)
 
@@ -206,7 +206,7 @@ class InwardSuppliesGSTSummary(
 ):
     def __init__(self, filters: dict) -> None:
         super().__init__()
-        filters.from_date, filters.to_date = filters.date_range
+        filters.from_date, filters.to_date = filters.get("date_range")
         self.filters = filters
         self._init_summary()
 
@@ -289,7 +289,7 @@ class InwardSuppliesGSTSummary(
             summary_entry = self.summary[category]
 
         for tax_field in TAX_FIELDS:
-            summary_entry[tax_field] += getattr(row, tax_field)
+            summary_entry[tax_field] += row.get(tax_field, 0)
 
     def _build_transformed_summary(self) -> list[dict]:
         transformed = []

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
@@ -17,11 +17,11 @@ TAX_FIELDS = (
 
 
 def execute(filters: dict | None = None) -> tuple[list[dict], list[dict]]:
-    report = GSTSummaryReport(filters)
+    report = InwardSuppliesGSTSummary(filters)
     return report.get_columns(), report.get_data()
 
 
-class GSTSummaryMapping:
+class InwardSuppliesGSTSummaryMapping:
     def __init__(self) -> None:
         self.mapping = {
             "A": {
@@ -63,7 +63,7 @@ class GSTSummaryMapping:
         return self.mapping.get(category, {}).get("has_subcategory", False)
 
 
-class GSTSummaryCategory(GSTSummaryMapping):
+class InwardSuppliesGSTSummaryCategory(InwardSuppliesGSTSummaryMapping):
     def __init__(self) -> None:
         super().__init__()
         self.mapping["A"]["category"] = self._is_inward_supplies_from_registered
@@ -121,7 +121,7 @@ class GSTSummaryCategory(GSTSummaryMapping):
         return "Inputs"
 
 
-class GSTSummaryData:
+class InwardSuppliesGSTSummaryData:
     def _get_data(self, filters: dict) -> list[dict]:
         return chain(
             self._get_bill_of_entry_data(filters),
@@ -201,7 +201,9 @@ class GSTSummaryData:
         return query.run(as_dict=True)
 
 
-class GSTSummaryReport(GSTSummaryCategory, GSTSummaryData):
+class InwardSuppliesGSTSummary(
+    InwardSuppliesGSTSummaryCategory, InwardSuppliesGSTSummaryData
+):
     def __init__(self, filters: dict) -> None:
         super().__init__()
         filters.from_date, filters.to_date = filters.date_range

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
@@ -25,12 +25,12 @@ MAPPING_FIELD = {
         and row.get("is_ineligible_for_itc") == 0,
     },
     4: {
-        "title": "Import Of Goods",
+        "title": "Import Of Goods (including supplies from SEZ)",
         "get_detail_type": lambda row: row.get("itc_classification")
         == "Import Of Goods",
     },
     5: {
-        "title": "Import Of Services",
+        "title": "Import Of Services (excluding inward supplies from SEZ)",
         "get_detail_type": lambda row: row.get("itc_classification")
         == "Import Of Service"
         and row.get("gst_category") != "SEZ",

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
@@ -136,7 +136,7 @@ def get_purchase_invoice_data(filters: dict) -> list[list]:
     if filters.get("company_gstin"):
         query = query.where(doc.company_gstin == filters.company_gstin)
 
-    return query.run(as_dict=True, debug=True)
+    return query.run(as_dict=True)
 
 
 def get_bill_of_entry_data(filters: dict) -> list[list]:
@@ -172,7 +172,7 @@ def get_bill_of_entry_data(filters: dict) -> list[list]:
         )
     )
 
-    return query.run(as_dict=True, debug=True)
+    return query.run(as_dict=True)
 
 
 def get_initial_summary() -> dict:

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
@@ -76,7 +76,7 @@ INWARD_SUPPLIES_CATEGORY_MAPPING = {
 
 
 class InwardSuppliesGSTSummaryCategory:
-    def get_category(self, row: dict) -> None:
+    def get_category(self, row: dict) -> InwardSuppliesCategory | None:
         gst_category = row.get("gst_category")
         itc_classification = row.get("itc_classification")
         is_reverse_charge = row.get("is_reverse_charge")
@@ -103,8 +103,12 @@ class InwardSuppliesGSTSummaryCategory:
         elif itc_classification == "Input Service Distributor":
             return InwardSuppliesCategory.ITC_FROM_ISD
 
-    def get_subcategory(self, row: dict, category: InwardSuppliesCategory) -> None:
-        if not category.has_subcategory:
+        return None
+
+    def get_subcategory(
+        self, row: dict, category: InwardSuppliesCategory
+    ) -> InwardSuppliesSubCategory | None:
+        if not category or not category.has_subcategory:
             return None
 
         if row.get("is_fixed_asset") == 1:
@@ -206,7 +210,7 @@ class InwardSuppliesGSTSummary(
         filters.from_date, filters.to_date = filters.get("date_range")
         self.filters = filters
 
-    def get_init_summary(self) -> None:
+    def get_initial_summary(self) -> dict:
         _zero_taxes = {tax_field: 0 for tax_field in TAX_FIELDS}
 
         summary = {}
@@ -258,16 +262,19 @@ class InwardSuppliesGSTSummary(
     def get_data(self) -> list[dict]:
         data = self._get_data(self.filters)
 
-        summary = self.get_init_summary()
+        summary = self.get_initial_summary()
 
         for row in data:
             category = self.get_category(row)
+            if not category or not (_summary_dict := summary.get(category)):
+                continue
+
             sub_category = self.get_subcategory(row, category)
 
-            _summary_dict = summary.get(category)
-
-            if sub_category:
-                _summary_dict = _summary_dict.get(sub_category)
+            if not sub_category or not (
+                _summary_dict := _summary_dict.get(sub_category)
+            ):
+                continue
 
             for tax_field in TAX_FIELDS:
                 _summary_dict[tax_field] += row.get(tax_field, 0)

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
@@ -6,7 +6,7 @@ from itertools import chain
 import frappe
 from frappe import _
 from frappe.query_builder import Case
-from frappe.query_builder.functions import LiteralValue
+from frappe.query_builder.custom import ConstantColumn
 
 TAX_FIELDS = (
     "igst_amount",
@@ -181,7 +181,7 @@ class InwardSuppliesGSTSummaryData:
                 Case("itc_classification")
                 .when(doc_item.gst_hsn_code.like("99%"), "Import Of Service")
                 .else_("Import Of Goods"),
-                LiteralValue("'Overseas'").as_("gst_category"),
+                ConstantColumn("Overseas").as_("gst_category"),
                 item.is_fixed_asset,
                 doc_item.gst_hsn_code,
                 doc_item.cgst_amount,

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
@@ -31,8 +31,7 @@ MAPPING_FIELD = {
     },
     5: {
         "title": "Import Of Services (excluding inward supplies from SEZ)",
-        "is_part_of": lambda row: row.get("itc_classification") == "Import Of Service"
-        and row.get("gst_category") != "SEZ",
+        "is_part_of": lambda row: row.get("itc_classification") == "Import Of Service",
     },
     6: {
         "title": "Input Tax credit received from ISD",

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
@@ -10,18 +10,18 @@ MAPPING_FIELD = {
     1: {
         "title": "Inward supplies (other than imports and inward supplies liable to reverse charge but includes services received from SEZs)",
         "is_part_of": lambda row: row.get("gst_category") == "Unregistered"
-        and row.get("is_reverse_charge") == 0,
+        and not row.get("is_reverse_charge"),
     },
     2: {
         "title": "Inward supplies received from unregistered persons liable to reverse charge (other than B above) on which tax is paid & ITC availed",
         "is_part_of": lambda row: row.get("gst_category") == "Unregistered"
-        and row.get("is_reverse_charge") == 1
+        and row.get("is_reverse_charge")
         and row.get("is_ineligible_for_itc") == 0,
     },
     3: {
         "title": "Inward supplies received from registered persons liable to reverse charge (other than B above) on which tax is paid & ITC availed",
         "is_part_of": lambda row: row.get("gst_category") != "Unregistered"
-        and row.get("is_reverse_charge") == 1
+        and row.get("is_reverse_charge")
         and row.get("is_ineligible_for_itc") == 0,
     },
     4: {
@@ -42,6 +42,7 @@ MAPPING_FIELD = {
 
 
 def execute(filters: dict | None = None) -> tuple[list[dict], list[dict]]:
+    filters.from_date, filters.to_date = filters.date_range
     return get_columns(), get_data(filters)
 
 
@@ -104,27 +105,25 @@ def get_purchase_invoice_data(filters: dict) -> list[list]:
     doc = frappe.qb.DocType("Purchase Invoice")
     doc_item = frappe.qb.DocType("Purchase Invoice Item")
 
-    from_date, to_date = filters.date_range
-
     query = (
         frappe.qb.from_(doc)
         .inner_join(doc_item)
         .on(doc.name == doc_item.parent)
         .select(
-            doc.gst_category.as_("gst_category"),
-            doc.itc_classification.as_("itc_classification"),
-            doc_item.is_ineligible_for_itc.as_("is_ineligible_for_itc"),
-            doc_item.is_fixed_asset.as_("is_fixed_asset"),
-            doc.is_reverse_charge.as_("is_reverse_charge"),
-            doc_item.gst_hsn_code.as_("gst_hsn_code"),
-            doc_item.cgst_amount.as_("cgst_amount"),
-            doc_item.sgst_amount.as_("sgst_amount"),
-            doc_item.igst_amount.as_("igst_amount"),
+           doc.gst_category,
+            doc.itc_classification,
+            doc_item.is_ineligible_for_itc,
+            doc_item.is_fixed_asset,
+            doc.is_reverse_charge,
+            doc_item.gst_hsn_code,
+            doc_item.cgst_amount,
+            doc_item.sgst_amount,
+            doc_item.igst_amount,
             (doc_item.cess_amount + doc_item.cess_non_advol_amount).as_("cess_amount"),
         )
         .where(
             (doc.docstatus == 1)
-            & (doc.posting_date[from_date:to_date])
+            & (doc.posting_date[filters.from_date : filters.to_date])
             & (doc.company == filters.company)
             & (doc.is_opening == "No")
         )
@@ -141,7 +140,6 @@ def get_bill_of_entry_data(filters: dict) -> list[list]:
     item = frappe.qb.DocType("Item")
     doc_item = frappe.qb.DocType("Bill of Entry Item")
 
-    from_date, to_date = filters.date_range
 
     query = (
         frappe.qb.from_(doc)
@@ -155,16 +153,16 @@ def get_bill_of_entry_data(filters: dict) -> list[list]:
             .else_("Import Of Goods"),
             LiteralValue("'Overseas'").as_("gst_category"),
             LiteralValue(False).as_("is_reverse_charge"),
-            item.is_fixed_asset.as_("is_fixed_asset"),
-            doc_item.gst_hsn_code.as_("gst_hsn_code"),
-            doc_item.cgst_amount.as_("cgst_amount"),
-            doc_item.sgst_amount.as_("sgst_amount"),
-            doc_item.igst_amount.as_("igst_amount"),
+            item.is_fixed_asset,
+            doc_item.gst_hsn_code,
+            doc_item.cgst_amount,
+            doc_item.sgst_amount,
+            doc_item.igst_amount,
             (doc_item.cess_amount + doc_item.cess_non_advol_amount).as_("cess_amount"),
         )
         .where(
             (doc.docstatus == 1)
-            & (doc.posting_date[from_date:to_date])
+            & (doc.posting_date[filters.from_date : filters.to_date])
             & (doc.company == filters.company)
         )
     )

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
@@ -80,7 +80,7 @@ def get_columns() -> list[dict]:
     ]
 
 
-def get_data(filters) -> list[dict]:
+def get_data(filters: dict) -> list[dict]:
     data = []
     data.extend(get_purchase_invoice_data(filters))
     data.extend(get_bill_of_entry_data(filters))
@@ -174,7 +174,7 @@ def get_bill_of_entry_data(filters: dict) -> list[list]:
 
 
 def get_initial_summary() -> dict:
-    _tax_amount = {
+    zero_taxes  = {
         "integrated_tax": 0,
         "central_tax": 0,
         "state_ut_tax": 0,
@@ -183,36 +183,36 @@ def get_initial_summary() -> dict:
 
     return {
         1: {
-            "Inputs": {**_tax_amount},
-            "Capital Goods": {**_tax_amount},
-            "Input Services": {**_tax_amount},
+            "Inputs": {**zero_taxes},
+            "Capital Goods": {**zero_taxes},
+            "Input Services": {**zero_taxes},
         },
         2: {
-            "Inputs": {**_tax_amount},
-            "Capital Goods": {**_tax_amount},
-            "Input Services": {**_tax_amount},
+            "Inputs": {**zero_taxes},
+            "Capital Goods": {**zero_taxes},
+            "Input Services": {**zero_taxes},
         },
         3: {
-            "Inputs": {**_tax_amount},
-            "Capital Goods": {**_tax_amount},
-            "Input Services": {**_tax_amount},
+            "Inputs": {**zero_taxes},
+            "Capital Goods": {**zero_taxes},
+            "Input Services": {**zero_taxes},
         },
         4: {
-            "Inputs": {**_tax_amount},
-            "Capital Goods": {**_tax_amount},
+            "Inputs": {**zero_taxes},
+            "Capital Goods": {**zero_taxes},
         },
-        5: {**_tax_amount},
-        6: {**_tax_amount},
+        5: {**zero_taxes},
+        6: {**zero_taxes},
     }
 
 
-def get_detail_type(row) -> int:
+def get_detail_type(row: dict) -> int:
     for detail_type, mapping in MAPPING_FIELD.items():
         if mapping["is_part_of"](row):
             return detail_type
 
 
-def add_subcategory_summary(summary, row) -> dict:
+def add_subcategory_summary(summary: dict, row: dict) -> None:
     if row["is_fixed_asset"] == 1:
         key = "Capital Goods"
 
@@ -227,54 +227,47 @@ def add_subcategory_summary(summary, row) -> dict:
     summary[key]["cess"] += row.cess_amount
 
 
-def get_transformed_summary(summary) -> list[dict]:
+def get_transformed_summary(summary: dict) -> list[dict]:
     transformed_summary = []
     for detail_type, subcategory in summary.items():
+        title = MAPPING_FIELD[detail_type]["title"]
         if detail_type in (1, 2, 3, 4):
-            transformed_summary.append(
-                {
-                    "details": MAPPING_FIELD[detail_type]["title"],
-                    "integrated_tax": sum(
-                        [
-                            subcategory[subcat]["integrated_tax"]
-                            for subcat in subcategory
-                        ]
-                    ),
-                    "central_tax": sum(
-                        [subcategory[subcat]["central_tax"] for subcat in subcategory]
-                    ),
-                    "state_ut_tax": sum(
-                        [subcategory[subcat]["state_ut_tax"] for subcat in subcategory]
-                    ),
-                    "cess": sum(
-                        [subcategory[subcat]["cess"] for subcat in subcategory]
-                    ),
-                    "indent": 0,
-                }
-            )
+            total_taxes = aggregate_taxes(subcategory)
+            transformed_summary.append(get_tax_summary_row(title, total_taxes, indent=0))
 
-            for subcategory_name, tax_amounts in subcategory.items():
+            for subcat_name, taxes in subcategory.items():
                 transformed_summary.append(
-                    {
-                        "details": subcategory_name,
-                        "integrated_tax": tax_amounts["integrated_tax"],
-                        "central_tax": tax_amounts["central_tax"],
-                        "state_ut_tax": tax_amounts["state_ut_tax"],
-                        "cess": tax_amounts["cess"],
-                        "indent": 1,
-                    }
+                   get_tax_summary_row(subcat_name, taxes, indent=1)
                 )
 
         else:
             transformed_summary.append(
-                {
-                    "details": MAPPING_FIELD[detail_type]["title"],
-                    "integrated_tax": subcategory["integrated_tax"],
-                    "central_tax": subcategory["central_tax"],
-                    "state_ut_tax": subcategory["state_ut_tax"],
-                    "cess": subcategory["cess"],
-                    "indent": 0,
-                }
+                get_tax_summary_row(title, subcategory, indent=0)
             )
 
     return transformed_summary
+
+def get_tax_summary_row(details: str, taxes: dict, indent: int = 0) -> dict:
+    return {
+        "details": details,
+        "integrated_tax": taxes.get("integrated_tax", 0),
+        "central_tax": taxes.get("central_tax", 0),
+        "state_ut_tax": taxes.get("state_ut_tax", 0),
+        "cess": taxes.get("cess", 0),
+        "indent": indent,
+    }
+
+
+def aggregate_taxes(subcategory: dict) -> dict:
+    return {
+        "integrated_tax": sum(
+            tax_item.get("integrated_tax", 0) for tax_item in subcategory.values()
+        ),
+        "central_tax": sum(
+            tax_item.get("central_tax", 0) for tax_item in subcategory.values()
+        ),
+        "state_ut_tax": sum(
+            tax_item.get("state_ut_tax", 0) for tax_item in subcategory.values()
+        ),
+        "cess": sum(tax_item.get("cess", 0) for tax_item in subcategory.values()),
+    }

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
@@ -1,275 +1,331 @@
 # Copyright (c) 2025, Resilient Tech and contributors
 # For license information, please see license.txt
 
+from itertools import chain
+
 import frappe
 from frappe import _
 from frappe.query_builder import Case
 from frappe.query_builder.functions import LiteralValue
 
-MAPPING_FIELD = {
-    1: {
-        "title": "Inward supplies (other than imports and inward supplies liable to reverse charge but includes services received from SEZs)",
-        "is_part_of": lambda row: row.get("gst_category") == "Unregistered"
-        and not row.get("is_reverse_charge"),
-    },
-    2: {
-        "title": "Inward supplies received from unregistered persons liable to reverse charge (other than B above) on which tax is paid & ITC availed",
-        "is_part_of": lambda row: row.get("gst_category") == "Unregistered"
-        and row.get("is_reverse_charge")
-        and row.get("is_ineligible_for_itc") == 0,
-    },
-    3: {
-        "title": "Inward supplies received from registered persons liable to reverse charge (other than B above) on which tax is paid & ITC availed",
-        "is_part_of": lambda row: row.get("gst_category") != "Unregistered"
-        and row.get("is_reverse_charge")
-        and row.get("is_ineligible_for_itc") == 0,
-    },
-    4: {
-        "title": "Import Of Goods (including supplies from SEZ)",
-        "is_part_of": lambda row: row.get("itc_classification") == "Import Of Goods"
-        and row.get("gst_category") == "SEZ",
-    },
-    5: {
-        "title": "Import Of Services (excluding inward supplies from SEZ)",
-        "is_part_of": lambda row: row.get("itc_classification") == "Import Of Service",
-    },
-    6: {
-        "title": "Input Tax credit received from ISD",
-        "is_part_of": lambda row: row.get("itc_classification")
-        == "Input Service Distributor",
-    },
-}
+TAX_FIELDS = (
+    "igst_amount",
+    "cgst_amount",
+    "sgst_amount",
+    "cess_amount",
+)
 
 
 def execute(filters: dict | None = None) -> tuple[list[dict], list[dict]]:
-    filters.from_date, filters.to_date = filters.date_range
-    return get_columns(), get_data(filters)
+    report = GSTSummaryReport(filters)
+    return report.get_columns(), report.get_data()
 
 
-def get_columns() -> list[dict]:
-    return [
-        {
-            "label": _("Details"),
-            "fieldname": "details",
-            "fieldtype": "Data",
-            "width": 1000,
-        },
-        {
-            "label": _("Integrated tax (₹)"),
-            "fieldname": "igst_amount",
-            "fieldtype": "Currency",
-            "width": 150,
-        },
-        {
-            "label": _("Central tax (₹)"),
-            "fieldname": "cgst_amount",
-            "fieldtype": "Currency",
-            "width": 150,
-        },
-        {
-            "label": _("State/UT tax (₹)"),
-            "fieldname": "sgst_amount",
-            "fieldtype": "Currency",
-            "width": 150,
-        },
-        {
-            "label": _("Cess (₹)"),
-            "fieldname": "cess_amount",
-            "fieldtype": "Currency",
-            "width": 150,
-        },
-    ]
+class GSTSummaryMapping:
+    def __init__(self) -> None:
+        self.mapping = {
+            "A": {
+                "title": "Inward supplies (other than imports and inward supplies liable to reverse charge but includes services received from SEZs)",
+                "category": ...,
+                "has_subcategory": True,
+            },
+            "B": {
+                "title": "Inward supplies received from unregistered persons liable to reverse charge (other than A above) on which tax is paid & ITC availed",
+                "category": ...,
+                "has_subcategory": True,
+            },
+            "C": {
+                "title": "Inward supplies received from registered persons liable to reverse charge (other than A above) on which tax is paid & ITC availed",
+                "category": ...,
+                "has_subcategory": True,
+            },
+            "D": {
+                "title": "Import Of Goods (including supplies from SEZ)",
+                "category": ...,
+                "has_subcategory": True,
+            },
+            "E": {
+                "title": "Import Of Services (excluding inward supplies from SEZ)",
+                "category": ...,
+                "has_subcategory": False,
+            },
+            "F": {
+                "title": "Input Tax credit received from ISD",
+                "category": ...,
+                "has_subcategory": False,
+            },
+        }
+
+    def get_title(self, category: str) -> str:
+        return self.mapping.get(category, {}).get("title")
+
+    def has_subcategory(self, category: str) -> bool:
+        return self.mapping.get(category, {}).get("has_subcategory", False)
 
 
-def get_data(filters: dict) -> list[dict]:
-    data = []
-    data.extend(get_purchase_invoice_data(filters))
-    data.extend(get_bill_of_entry_data(filters))
+class GSTSummaryCategory(GSTSummaryMapping):
+    def __init__(self) -> None:
+        super().__init__()
+        self.mapping["A"]["category"] = self._is_inward_supplies_from_registered
+        self.mapping["B"]["category"] = self._is_inward_supplies_from_unregistered
+        self.mapping["C"][
+            "category"
+        ] = self._is_inward_supplies_from_registered_reverse_charge
+        self.mapping["D"]["category"] = self._is_import_of_goods_sez
+        self.mapping["E"]["category"] = self._is_import_of_services
+        self.mapping["F"]["category"] = self._is_itc_received_from_isd
 
-    summary = get_initial_summary()
-
-    for row in data:
-        detail_type = get_detail_type(row)
-        if detail_type in (1, 2, 3, 4):
-            add_subcategory_summary(summary[detail_type], row)
-
-        elif detail_type in (5, 6):
-            summary[detail_type]["igst_amount"] += row.igst_amount
-            summary[detail_type]["cgst_amount"] += row.cgst_amount
-            summary[detail_type]["sgst_amount"] += row.sgst_amount
-            summary[detail_type]["cess_amount"] += row.cess_amount
-    return get_transformed_summary(summary)
-
-
-def get_purchase_invoice_data(filters: dict) -> list[list]:
-    doc = frappe.qb.DocType("Purchase Invoice")
-    doc_item = frappe.qb.DocType("Purchase Invoice Item")
-
-    query = (
-        frappe.qb.from_(doc)
-        .inner_join(doc_item)
-        .on(doc.name == doc_item.parent)
-        .select(
-           doc.gst_category,
-            doc.itc_classification,
-            doc_item.is_ineligible_for_itc,
-            doc_item.is_fixed_asset,
-            doc.is_reverse_charge,
-            doc_item.gst_hsn_code,
-            doc_item.cgst_amount,
-            doc_item.sgst_amount,
-            doc_item.igst_amount,
-            (doc_item.cess_amount + doc_item.cess_non_advol_amount).as_("cess_amount"),
+    def _is_inward_supplies_from_registered(self, row: dict) -> bool:
+        return (
+            row.get("gst_category") != "Overseas"
+            and not row.get("is_reverse_charge")
+            and row.get("itc_classification") != "Input Service Distributor"
         )
-        .where(
-            (doc.docstatus == 1)
-            & (doc.posting_date[filters.from_date : filters.to_date])
-            & (doc.company == filters.company)
-            & (doc.company_gstin != doc.supplier_gstin)
-            & (doc.is_opening == "No")
+
+    def _is_inward_supplies_from_unregistered(self, row: dict) -> bool:
+        return row.get("gst_category") == "Unregistered" and row.get(
+            "is_reverse_charge"
         )
-    )
 
-    if filters.get("company_gstin"):
-        query = query.where(doc.company_gstin == filters.company_gstin)
-
-    return query.run(as_dict=True)
-
-
-def get_bill_of_entry_data(filters: dict) -> list[list]:
-    doc = frappe.qb.DocType("Bill of Entry")
-    item = frappe.qb.DocType("Item")
-    doc_item = frappe.qb.DocType("Bill of Entry Item")
-
-
-    query = (
-        frappe.qb.from_(doc)
-        .inner_join(doc_item)
-        .on(doc.name == doc_item.parent)
-        .inner_join(item)
-        .on(doc_item.item_code == item.name)
-        .select(
-            Case("itc_classification")
-            .when(doc_item.gst_hsn_code.like("99%"), "Import Of Service")
-            .else_("Import Of Goods"),
-            LiteralValue("'Overseas'").as_("gst_category"),
-            LiteralValue(False).as_("is_reverse_charge"),
-            item.is_fixed_asset,
-            doc_item.gst_hsn_code,
-            doc_item.cgst_amount,
-            doc_item.sgst_amount,
-            doc_item.igst_amount,
-            (doc_item.cess_amount + doc_item.cess_non_advol_amount).as_("cess_amount"),
+    def _is_inward_supplies_from_registered_reverse_charge(self, row: dict) -> bool:
+        return row.get("gst_category") != "Unregistered" and row.get(
+            "is_reverse_charge"
         )
-        .where(
-            (doc.docstatus == 1)
-            & (doc.posting_date[filters.from_date : filters.to_date])
-            & (doc.company == filters.company)
+
+    def _is_import_of_goods_sez(self, row: dict) -> bool:
+        return row.get("itc_classification") == "Import Of Goods"
+
+    def _is_import_of_services(self, row: dict) -> bool:
+        return row.get("itc_classification") == "Import Of Service"
+
+    def _is_itc_received_from_isd(self, row: dict) -> bool:
+        return row.get("itc_classification") == "Input Service Distributor"
+
+    def get_category(self, row: dict) -> str:
+        for detail_type, mapping in self.mapping.items():
+            if (fn := mapping["category"]) and fn(row):
+                return detail_type
+
+    def get_subcategory(self, category: str, row: dict) -> str | None:
+        if not self.has_subcategory(category):
+            return None
+
+        if row.get("is_fixed_asset") == 1:
+            return "Capital Goods"
+
+        if (gst_hsn_code := row.get("gst_hsn_code")) and (
+            gst_hsn_code.startswith("99")
+        ):
+            return "Input Services"
+
+        return "Inputs"
+
+
+class GSTSummaryData:
+    def _get_data(self, filters: dict) -> list[dict]:
+        return chain(
+            self._get_bill_of_entry_data(filters),
+            self._get_purchase_invoice_data(filters),
         )
-    )
-    if filters.get("company_gstin"):
-        query = query.where(doc.company_gstin == filters.company_gstin)
 
-    return query.run(as_dict=True)
+    def _get_purchase_invoice_data(self, filters: dict) -> list[dict]:
+        doc = frappe.qb.DocType("Purchase Invoice")
+        doc_item = frappe.qb.DocType("Purchase Invoice Item")
+
+        query = (
+            frappe.qb.from_(doc)
+            .inner_join(doc_item)
+            .on(doc.name == doc_item.parent)
+            .select(
+                doc.gst_category,
+                doc.itc_classification,
+                doc_item.is_fixed_asset,
+                doc.is_reverse_charge,
+                doc_item.gst_hsn_code,
+                doc_item.cgst_amount,
+                doc_item.sgst_amount,
+                doc_item.igst_amount,
+                (doc_item.cess_amount + doc_item.cess_non_advol_amount).as_(
+                    "cess_amount"
+                ),
+            )
+            .where(
+                (doc.docstatus == 1)
+                & (doc.posting_date[filters.from_date : filters.to_date])
+                & (doc.company == filters.company)
+                & (doc.company_gstin != doc.supplier_gstin)
+                & (doc.is_opening == "No")
+            )
+        )
+
+        if filters.get("company_gstin"):
+            query = query.where(doc.company_gstin == filters.company_gstin)
+
+        return query.run(as_dict=True)
+
+    def _get_bill_of_entry_data(self, filters: dict) -> list[dict]:
+        doc = frappe.qb.DocType("Bill of Entry")
+        item = frappe.qb.DocType("Item")
+        doc_item = frappe.qb.DocType("Bill of Entry Item")
+
+        query = (
+            frappe.qb.from_(doc)
+            .inner_join(doc_item)
+            .on(doc.name == doc_item.parent)
+            .inner_join(item)
+            .on(doc_item.item_code == item.item_code)
+            .select(
+                Case("itc_classification")
+                .when(doc_item.gst_hsn_code.like("99%"), "Import Of Service")
+                .else_("Import Of Goods"),
+                LiteralValue("'Overseas'").as_("gst_category"),
+                item.is_fixed_asset,
+                doc_item.gst_hsn_code,
+                doc_item.cgst_amount,
+                doc_item.sgst_amount,
+                doc_item.igst_amount,
+                (doc_item.cess_amount + doc_item.cess_non_advol_amount).as_(
+                    "cess_amount"
+                ),
+            )
+            .where(
+                (doc.docstatus == 1)
+                & (doc.posting_date[filters.from_date : filters.to_date])
+                & (doc.company == filters.company)
+            )
+        )
+
+        if filters.get("company_gstin"):
+            query = query.where(doc.company_gstin == filters.company_gstin)
+
+        return query.run(as_dict=True)
 
 
-def get_initial_summary() -> dict:
-    zero_taxes  = {
-        "igst_amount": 0,
-        "cgst_amount": 0,
-        "sgst_amount": 0,
-        "cess_amount": 0,
-    }
+class GSTSummaryReport(GSTSummaryCategory, GSTSummaryData):
+    def __init__(self, filters: dict) -> None:
+        super().__init__()
+        filters.from_date, filters.to_date = filters.date_range
+        self.filters = filters
+        self._init_summary()
 
-    return {
-        1: {
-            "Inputs": {**zero_taxes},
-            "Capital Goods": {**zero_taxes},
-            "Input Services": {**zero_taxes},
-        },
-        2: {
-            "Inputs": {**zero_taxes},
-            "Capital Goods": {**zero_taxes},
-            "Input Services": {**zero_taxes},
-        },
-        3: {
-            "Inputs": {**zero_taxes},
-            "Capital Goods": {**zero_taxes},
-            "Input Services": {**zero_taxes},
-        },
-        4: {
-            "Inputs": {**zero_taxes},
-            "Capital Goods": {**zero_taxes},
-        },
-        5: {**zero_taxes},
-        6: {**zero_taxes},
-    }
+    def _init_summary(self) -> None:
+        _zero_taxes = {tax_field: 0 for tax_field in TAX_FIELDS}
 
+        self.summary = {
+            "A": {
+                "Inputs": {**_zero_taxes},
+                "Capital Goods": {**_zero_taxes},
+                "Input Services": {**_zero_taxes},
+            },
+            "B": {
+                "Inputs": {**_zero_taxes},
+                "Capital Goods": {**_zero_taxes},
+                "Input Services": {**_zero_taxes},
+            },
+            "C": {
+                "Inputs": {**_zero_taxes},
+                "Capital Goods": {**_zero_taxes},
+                "Input Services": {**_zero_taxes},
+            },
+            "D": {
+                "Inputs": {**_zero_taxes},
+                "Capital Goods": {**_zero_taxes},
+            },
+            "E": {**_zero_taxes},
+            "F": {**_zero_taxes},
+        }
 
-def get_detail_type(row: dict) -> int:
-    for detail_type, mapping in MAPPING_FIELD.items():
-        if mapping["is_part_of"](row):
-            return detail_type
+    def get_columns(self) -> list[dict]:
+        return [
+            {
+                "label": _("Details"),
+                "fieldname": "details",
+                "fieldtype": "Data",
+                "width": 1000,
+            },
+            {
+                "label": _("Integrated tax (₹)"),
+                "fieldname": "igst_amount",
+                "fieldtype": "Currency",
+                "width": 150,
+            },
+            {
+                "label": _("Central tax (₹)"),
+                "fieldname": "cgst_amount",
+                "fieldtype": "Currency",
+                "width": 150,
+            },
+            {
+                "label": _("State/UT tax (₹)"),
+                "fieldname": "sgst_amount",
+                "fieldtype": "Currency",
+                "width": 150,
+            },
+            {
+                "label": _("Cess (₹)"),
+                "fieldname": "cess_amount",
+                "fieldtype": "Currency",
+                "width": 150,
+            },
+        ]
 
+    def get_data(self) -> list[dict]:
+        data = self._get_data(self.filters)
 
-def add_subcategory_summary(summary: dict, row: dict) -> None:
-    if row["is_fixed_asset"] == 1:
-        key = "Capital Goods"
+        for row in data:
+            self._add_to_summary(row)
 
-    elif row["gst_hsn_code"] and row["gst_hsn_code"].startswith("99"):
-        key = "Input Services"
-    else:
-        key = "Inputs"
+        return self._build_transformed_summary()
 
-    summary[key]["igst_amount"] += row.igst_amount
-    summary[key]["cgst_amount"] += row.cgst_amount
-    summary[key]["sgst_amount"] += row.sgst_amount
-    summary[key]["cess_amount"] += row.cess_amount
+    def _add_to_summary(self, row: dict) -> None:
+        category = self.get_category(row)
+        subcategory = self.get_subcategory(category, row)
 
-
-def get_transformed_summary(summary: dict) -> list[dict]:
-    transformed_summary = []
-    for detail_type, subcategory in summary.items():
-        title = MAPPING_FIELD[detail_type]["title"]
-        if detail_type in (1, 2, 3, 4):
-            total_taxes = aggregate_taxes(subcategory)
-            transformed_summary.append(get_tax_summary_row(title, total_taxes, indent=0))
-
-            for subcat_name, taxes in subcategory.items():
-                transformed_summary.append(
-                   get_tax_summary_row(subcat_name, taxes, indent=1)
-                )
-
+        if subcategory:
+            summary_entry = self.summary[category][subcategory]
         else:
-            transformed_summary.append(
-                get_tax_summary_row(title, subcategory, indent=0)
+            summary_entry = self.summary[category]
+
+        for tax_field in TAX_FIELDS:
+            summary_entry[tax_field] += getattr(row, tax_field)
+
+    def _build_transformed_summary(self) -> list[dict]:
+        transformed = []
+
+        for category, summary in self.summary.items():
+            title = self.get_title(category)
+            has_subcategory = self.has_subcategory(category)
+
+            transformed.append(
+                self._create_entry(
+                    f"{category}) {title}",
+                    self._aggregate_summary(summary) if has_subcategory else summary,
+                    indent=0,
+                )
             )
 
-    return transformed_summary
+            if has_subcategory:
+                for subcategory, sub_summary in summary.items():
+                    transformed.append(
+                        self._create_entry(subcategory, sub_summary, indent=1)
+                    )
+            else:
+                transformed.append(self._create_entry(title, summary, indent=1))
 
-def get_tax_summary_row(details: str, taxes: dict, indent: int = 0) -> dict:
-    return {
-        "details": details,
-        "igst_amount": taxes.get("igst_amount", 0),
-        "cgst_amount": taxes.get("cgst_amount", 0),
-        "sgst_amount": taxes.get("sgst_amount", 0),
-        "cess_amount": taxes.get("cess_amount", 0),
-        "indent": indent,
-    }
+        return transformed
 
+    def _aggregate_summary(self, summary: dict) -> dict:
+        totals = {tax_field: 0 for tax_field in TAX_FIELDS}
 
-def aggregate_taxes(subcategory: dict) -> dict:
-    return {
-       "igst_amount": sum(
-            tax_item.get("igst_amount", 0) for tax_item in subcategory.values()
-        ),
-        "cgst_amount": sum(
-            tax_item.get("cgst_amount", 0) for tax_item in subcategory.values()
-        ),
-       "sgst_amount": sum(
-            tax_item.get("sgst_amount", 0) for tax_item in subcategory.values()
-        ),
-        "cess_amount": sum(
-            tax_item.get("cess_amount", 0) for tax_item in subcategory.values()
-        ),
-    }
+        for taxes in summary.values():
+            for tax_field in TAX_FIELDS:
+                totals[tax_field] += taxes.get(tax_field, 0)
+
+        return totals
+
+    def _create_entry(self, details: str, summary_data: dict, indent: int = 0) -> dict:
+        return {
+            "details": details,
+            **summary_data,
+            "indent": indent,
+        }

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
@@ -56,25 +56,25 @@ def get_columns() -> list[dict]:
         },
         {
             "label": _("Integrated tax (₹)"),
-            "fieldname": "integrated_tax",
+            "fieldname": "igst_amount",
             "fieldtype": "Currency",
             "width": 150,
         },
         {
             "label": _("Central tax (₹)"),
-            "fieldname": "central_tax",
+            "fieldname": "cgst_amount",
             "fieldtype": "Currency",
             "width": 150,
         },
         {
             "label": _("State/UT tax (₹)"),
-            "fieldname": "state_ut_tax",
+            "fieldname": "sgst_amount",
             "fieldtype": "Currency",
             "width": 150,
         },
         {
             "label": _("Cess (₹)"),
-            "fieldname": "cess",
+            "fieldname": "cess_amount",
             "fieldtype": "Currency",
             "width": 150,
         },
@@ -94,11 +94,10 @@ def get_data(filters: dict) -> list[dict]:
             add_subcategory_summary(summary[detail_type], row)
 
         elif detail_type in (5, 6):
-            summary[detail_type]["integrated_tax"] += row.igst_amount
-            summary[detail_type]["central_tax"] += row.cgst_amount
-            summary[detail_type]["state_ut_tax"] += row.sgst_amount
-            summary[detail_type]["cess"] += row.cess_amount
-
+            summary[detail_type]["igst_amount"] += row.igst_amount
+            summary[detail_type]["cgst_amount"] += row.cgst_amount
+            summary[detail_type]["sgst_amount"] += row.sgst_amount
+            summary[detail_type]["cess_amount"] += row.cess_amount
     return get_transformed_summary(summary)
 
 
@@ -176,10 +175,10 @@ def get_bill_of_entry_data(filters: dict) -> list[list]:
 
 def get_initial_summary() -> dict:
     zero_taxes  = {
-        "integrated_tax": 0,
-        "central_tax": 0,
-        "state_ut_tax": 0,
-        "cess": 0,
+        "igst_amount": 0,
+        "cgst_amount": 0,
+        "sgst_amount": 0,
+        "cess_amount": 0,
     }
 
     return {
@@ -222,10 +221,10 @@ def add_subcategory_summary(summary: dict, row: dict) -> None:
     else:
         key = "Inputs"
 
-    summary[key]["integrated_tax"] += row.igst_amount
-    summary[key]["central_tax"] += row.cgst_amount
-    summary[key]["state_ut_tax"] += row.sgst_amount
-    summary[key]["cess"] += row.cess_amount
+    summary[key]["igst_amount"] += row.igst_amount
+    summary[key]["cgst_amount"] += row.cgst_amount
+    summary[key]["sgst_amount"] += row.sgst_amount
+    summary[key]["cess_amount"] += row.cess_amount
 
 
 def get_transformed_summary(summary: dict) -> list[dict]:
@@ -251,24 +250,26 @@ def get_transformed_summary(summary: dict) -> list[dict]:
 def get_tax_summary_row(details: str, taxes: dict, indent: int = 0) -> dict:
     return {
         "details": details,
-        "integrated_tax": taxes.get("integrated_tax", 0),
-        "central_tax": taxes.get("central_tax", 0),
-        "state_ut_tax": taxes.get("state_ut_tax", 0),
-        "cess": taxes.get("cess", 0),
+        "igst_amount": taxes.get("igst_amount", 0),
+        "cgst_amount": taxes.get("cgst_amount", 0),
+        "sgst_amount": taxes.get("sgst_amount", 0),
+        "cess_amount": taxes.get("cess_amount", 0),
         "indent": indent,
     }
 
 
 def aggregate_taxes(subcategory: dict) -> dict:
     return {
-        "integrated_tax": sum(
-            tax_item.get("integrated_tax", 0) for tax_item in subcategory.values()
+       "igst_amount": sum(
+            tax_item.get("igst_amount", 0) for tax_item in subcategory.values()
         ),
-        "central_tax": sum(
-            tax_item.get("central_tax", 0) for tax_item in subcategory.values()
+        "cgst_amount": sum(
+            tax_item.get("cgst_amount", 0) for tax_item in subcategory.values()
         ),
-        "state_ut_tax": sum(
-            tax_item.get("state_ut_tax", 0) for tax_item in subcategory.values()
+       "sgst_amount": sum(
+            tax_item.get("sgst_amount", 0) for tax_item in subcategory.values()
         ),
-        "cess": sum(tax_item.get("cess", 0) for tax_item in subcategory.values()),
+        "cess_amount": sum(
+            tax_item.get("cess_amount", 0) for tax_item in subcategory.values()
+        ),
     }

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
@@ -125,6 +125,7 @@ def get_purchase_invoice_data(filters: dict) -> list[list]:
             (doc.docstatus == 1)
             & (doc.posting_date[filters.from_date : filters.to_date])
             & (doc.company == filters.company)
+            & (doc.company_gstin != doc.supplier_gstin)
             & (doc.is_opening == "No")
         )
     )
@@ -166,6 +167,8 @@ def get_bill_of_entry_data(filters: dict) -> list[list]:
             & (doc.company == filters.company)
         )
     )
+    if filters.get("company_gstin"):
+        query = query.where(doc.company_gstin == filters.company_gstin)
 
     return query.run(as_dict=True)
 

--- a/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
+++ b/india_compliance/gst_india/report/summary_of_inward_supplies/summary_of_inward_supplies.py
@@ -9,35 +9,33 @@ from frappe.query_builder.functions import LiteralValue
 MAPPING_FIELD = {
     1: {
         "title": "Inward supplies (other than imports and inward supplies liable to reverse charge but includes services received from SEZs)",
-        "get_detail_type": lambda row: row.get("gst_category") != "Overseas"
+        "is_part_of": lambda row: row.get("gst_category") == "Unregistered"
         and row.get("is_reverse_charge") == 0,
     },
     2: {
         "title": "Inward supplies received from unregistered persons liable to reverse charge (other than B above) on which tax is paid & ITC availed",
-        "get_detail_type": lambda row: row.get("gst_category") == "Unregistered"
+        "is_part_of": lambda row: row.get("gst_category") == "Unregistered"
         and row.get("is_reverse_charge") == 1
         and row.get("is_ineligible_for_itc") == 0,
     },
     3: {
         "title": "Inward supplies received from registered persons liable to reverse charge (other than B above) on which tax is paid & ITC availed",
-        "get_detail_type": lambda row: row.get("gst_category") != "Unregistered"
+        "is_part_of": lambda row: row.get("gst_category") != "Unregistered"
         and row.get("is_reverse_charge") == 1
         and row.get("is_ineligible_for_itc") == 0,
     },
     4: {
         "title": "Import Of Goods (including supplies from SEZ)",
-        "get_detail_type": lambda row: row.get("itc_classification")
-        == "Import Of Goods",
+        "is_part_of": lambda row: row.get("itc_classification") == "Import Of Goods",
     },
     5: {
         "title": "Import Of Services (excluding inward supplies from SEZ)",
-        "get_detail_type": lambda row: row.get("itc_classification")
-        == "Import Of Service"
+        "is_part_of": lambda row: row.get("itc_classification") == "Import Of Service"
         and row.get("gst_category") != "SEZ",
     },
     6: {
         "title": "Input Tax credit received from ISD",
-        "get_detail_type": lambda row: row.get("itc_classification")
+        "is_part_of": lambda row: row.get("itc_classification")
         == "Input Service Distributor",
     },
 }
@@ -210,7 +208,7 @@ def get_initial_summary() -> dict:
 
 def get_detail_type(row) -> int:
     for detail_type, mapping in MAPPING_FIELD.items():
-        if mapping["get_detail_type"](row):
+        if mapping["is_part_of"](row):
             return detail_type
 
 

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from itertools import chain
 
 import frappe
-from frappe.utils import flt
+from frappe.utils import cint, flt
 
 from india_compliance.gst_india.constants import UOM_MAP
 from india_compliance.gst_india.report.gstr_1.gstr_1 import (
@@ -2380,8 +2380,10 @@ class BooksDataMapper:
         Round off the rounding difference values to 2 decimal places.
         This method is used to round off the rounding difference values.
         """
+        precision = cint(frappe.db.get_default("currency_precision")) or None
+
         for key, value in self.rounding_difference.items():
-            self.rounding_difference[key] = flt(value, self.PRECISION)
+            self.rounding_difference[key] = flt(value, precision)
 
         # saved as object -> it's normalized
         prepared_data["rounding_difference"] = {

--- a/india_compliance/gst_india/utils/gstr_1/test_gstr_1_books_data.py
+++ b/india_compliance/gst_india/utils/gstr_1/test_gstr_1_books_data.py
@@ -218,10 +218,10 @@ class TestGSTR1BooksData(FrappeTestCase):
         self.assertDictEq(
             {
                 "rounding_difference": {
-                    "total_taxable_value": -0.02,
+                    "total_taxable_value": -0.022,
                     "total_igst_amount": 0.0,
-                    "total_cgst_amount": 0.02,
-                    "total_sgst_amount": 0.02,
+                    "total_cgst_amount": 0.022,
+                    "total_sgst_amount": 0.022,
                     "total_cess_amount": 0.0,
                 }
             },
@@ -275,7 +275,7 @@ class TestGSTR1BooksData(FrappeTestCase):
         self.assertDictEq(
             {
                 "rounding_difference": {
-                    "total_taxable_value": -0.02,
+                    "total_taxable_value": -0.022,
                 }
             },
             data["rounding_difference"],

--- a/india_compliance/public/js/components/data_table_manager.js
+++ b/india_compliance/public/js/components/data_table_manager.js
@@ -4,6 +4,7 @@ india_compliance.DataTableManager = class DataTableManager {
     constructor(options) {
         Object.assign(this, options);
         this.data = this.data || [];
+        this.additional_total_rows = this.additional_total_rows || null;
         this.make();
     }
 
@@ -11,6 +12,7 @@ india_compliance.DataTableManager = class DataTableManager {
         this.format_data(this.data);
         this.make_no_data();
         this.render_datatable();
+        this.setup_additional_total_row();
 
         this.columns_dict = {};
         for (const column of this.datatable.getColumns()) {
@@ -28,6 +30,7 @@ india_compliance.DataTableManager = class DataTableManager {
         if (noDataMessage) this.datatable.options.noDataMessage = noDataMessage;
 
         this.datatable.refresh(data, columns);
+        this.refresh_additional_total_rows();
     }
 
     get_column(fieldname) {
@@ -143,5 +146,119 @@ india_compliance.DataTableManager = class DataTableManager {
         };
         this.datatable = new frappe.DataTable(this.$wrapper.get(0), datatable_options);
         this.$datatable = $(`.${this.datatable.style.scopeClass}`);
+    }
+    
+    setup_additional_total_row() {
+        if (!this.additional_total_rows) return;
+
+        const datatable = this.datatable;
+        const originalRenderFooter = datatable.bodyRenderer.renderFooter;
+
+        datatable.bodyRenderer.renderFooter = () => {
+            originalRenderFooter.call(datatable.bodyRenderer);
+            this.render_additional_total_rows();
+        };
+    }
+
+    refresh_additional_total_rows() {
+        if (!this.additional_total_rows) return;
+
+        this.remove_additional_total_rows();
+        this.render_additional_total_rows();
+    }
+
+    render_additional_total_rows() {
+        if (!this.additional_total_rows) return;
+
+        for (const row of this.additional_total_rows) {
+            this.render_additional_total_row(row);
+        }
+    }
+
+    render_additional_total_row(row) {
+        if (row.show && !row.show()) return;
+
+        const datatable = this.datatable;
+
+        const total_row_data = this.get_additional_total_row_data(row);
+        if (!total_row_data) return;
+
+        const html = datatable.rowmanager.getRowHTML(total_row_data, {
+            rowIndex: row.row_id,
+            isTotalRow: 1,
+        });
+
+        datatable.footer.insertAdjacentHTML("beforeend", html);
+
+        const $row = $(`[data-row-index='${row.row_id}']`);
+
+        $row.css(row.css_styles || { "font-weight": "bold" });
+    }
+
+    remove_additional_total_rows() {
+        if (!this.additional_total_rows) return;
+
+        for (const row of this.additional_total_rows) {
+            if (!row.row_id) continue;
+            $(`[data-row-index='${row.row_id}']`).remove();
+        }
+    }
+
+    get_additional_total_row_data(row) {
+        let data = this.get_row_data(row);
+        if (!data) return null;
+
+        const row_template = this.get_row_template(row);
+
+        const total_row_data = row_template.map(cell => {
+            if (cell.content === "") return cell;
+
+            const fieldname = cell.column.id;
+
+            if (row.label_column === fieldname) {
+                cell.content = row.label;
+            } else if (
+                cell.column._fieldtype === "Float" ||
+                cell.column.fieldtype === "Float"
+            ) {
+                cell.content = data[fieldname] || 0.0;
+            } else if (Object.prototype.hasOwnProperty.call(data, fieldname)) {
+                cell.content = data[fieldname];
+            }
+
+            return cell;
+        });
+
+        return total_row_data;
+    }
+
+    get_row_data(row) {
+        if (typeof row.data === "function") {
+            return row.data();
+        }
+
+        return row.data;
+    }
+
+    get_row_template(row) {
+        const datatable = this.datatable;
+        const columns = datatable.getColumns();
+
+        const row_template = columns.map(col => {
+            let content = null;
+
+            if (row?.exclude_columns.includes(col.id)) {
+                content = "";
+            }
+
+            return {
+                content,
+                isTotalRow: 1,
+                colIndex: col.colIndex,
+                column: col,
+            };
+        });
+
+        return row_template;
     }
 };

--- a/india_compliance/public/js/gst_api_handler.js
+++ b/india_compliance/public/js/gst_api_handler.js
@@ -48,7 +48,9 @@ Object.assign(india_compliance, {
                         },
                     });
                 },
+                static: true,
             });
+            prompt.get_close_btn().show();
             prompt.show();
         });
     },


### PR DESCRIPTION
**commits from 25-Jun-2025 to 3-July-2025**

**Fixes & Improvements**
- feat: add rounding difference row in gstr-1 beta
- fix: ignore audit trail validations in server-side actions
- fix: do not hide otp dialog when clicked outside the dialog
- Fix: fix the toggle_reverse_charge issue in without item invoice
- feat: Summary of Inward Supplies Report
- fix: remove debug=True
- fix: update titles for import categories to include SEZ details
- refactor: replace get_detail_type with is_part_of in MAPPING_FIELD for clarity
- refactor: improve total calculation in get_datatable_options for clarity
- refactor: improve readability and maintainability of tax summary trasformation
- refactor: do not go into reduce function if the column is details
- fix: check SEZ for Import Of Goods
- refactor: rename tax fields for consistency in summary
- refactor: remove SEZ condition from Import Of Services mapping as it is redundant
- refactor: update reverse charge conditions;  improve date range handling; remove unnecessary alias;
- fix: add company GSTIN conditions to purchase invoice and bill of entry data queries
- refactor: restructure;  improve maintainability;
- refactor: rename GST summary classes
- refactor: update dict access to get;
- refactor: simplify category mapping initialization
- refactor: replace LiteralValue with ConstantColumn
- refactor: enhance category and subcategory handling in GST summary
- refactor: update return types for category and subcategory methods in GST summary

